### PR TITLE
added reflector geometry, added Be and CuB4C materials

### DIFF
--- a/make_materials.py
+++ b/make_materials.py
@@ -46,6 +46,44 @@ def uranium(enrichment):
     U.metadata['mat_number'] = 3
     return U
 
+def beryllium():
+    nucvec = {40000: 1}
+    Be = Material(nucvec)
+    Be = Be.expand_elements()
+    Be.density = 1.85 #g/cm3
+    Be.metadata['mat_number'] = 11
+    return Be
+
+def copper():
+    nucvec = {290000: 1}
+    Cu = Material(nucvec)
+    Cu = Cu.expand_elements()
+    Cu.density = 8.96 #g/cm3
+    Cu.metadata['mat_number'] = 12
+    return Cu
+
+def boron():
+    nucvec = {50000: 1}
+    B = Material(nucvec)
+    B = B.expand_elements()
+    B.density = 2.3 #g/cm3
+    B.metadata['mat_number'] = 13
+    return B
+
+def copper_boron(Cu, B, C):
+    
+    # ref https://www.osti.gov/servlets/purl/1067489
+    B4C = Material()
+    B4C.from_atom_frac({B:4,C:1})
+    B4C.density = 2.5 #g/cm3
+
+    mix = MultiMaterial({Cu:0.5, B4C:0.5})
+
+    CuB = mix.mix_by_volume()
+    CuB.metadata['mat_number'] = 14
+
+    return CuB
+
 
 def uranium_carbide(U, C):
     UC = Material()
@@ -127,6 +165,9 @@ def main():
     C = carbon()
     Zr = zirconium()
     U = uranium(0.93)
+    Be = beryllium()
+    Cu = copper()
+    B = boron()
     ZrC = zirconium_carbide(Zr, C)
     UC = uranium_carbide(U, C)
     UZrC = mix_UZrC_graphite(38.4, 2.8, 58.5, 0.117)
@@ -134,11 +175,13 @@ def main():
     Inc_718 = inconel_718()
     H_STP = hydrogen_STP()
     ZrC_insulator = zirconium_carbide_insulator(ZrC)
+    CuB = copper_boron(Cu, B, C)
 
     # print em out and have a look
     print(C)
     print(Zr)
     print(U)
+    print(Be)
     print(ZrC)
     print(UC)
     print(UZrC)
@@ -146,6 +189,7 @@ def main():
     print(Inc_718)
     print(H_STP)
     print(ZrC_insulator)
+    print(CuB)
 
     # make the library and export to xml
     lib = MaterialLibrary()
@@ -159,6 +203,8 @@ def main():
     lib['inconel-718'] = Inc_718
     lib['Hydrogen STP'] = H_STP
     lib['zirconium_carbide_insulator'] = ZrC_insulator
+    lib['Beryllium'] = Be
+    lib['copper_boron'] = CuB
 
     lib.write_openmc('materials.xml')
 

--- a/materials.xml
+++ b/materials.xml
@@ -24,6 +24,15 @@
     <nuclide name="U235" ao="9.3082e-01" />
     <nuclide name="U238" ao="6.9177e-02" />
   </material>
+  <material id="14" name="copper_boron" >
+    <density value="5.73" units="g/cc" />
+    <nuclide name="B10" ao="9.8073e-02" />
+    <nuclide name="B11" ao="3.9476e-01" />
+    <nuclide name="C12" ao="1.2189e-01" />
+    <nuclide name="C13" ao="1.3183e-03" />
+    <nuclide name="Cu63" ao="2.6551e-01" />
+    <nuclide name="Cu65" ao="1.1845e-01" />
+  </material>
   <material id="5" name="zirconium_carbide" >
     <density value="6.59" units="g/cc" />
     <nuclide name="C12" ao="9.8930e-01" />
@@ -33,6 +42,10 @@
     <nuclide name="Zr92" ao="1.7150e-01" />
     <nuclide name="Zr94" ao="1.7380e-01" />
     <nuclide name="Zr96" ao="2.8000e-02" />
+  </material>
+  <material id="11" name="Beryllium" >
+    <density value="1.85" units="g/cc" />
+    <nuclide name="Be9" ao="1.0000e+00" />
   </material>
   <material id="10" name="zirconium_carbide_insulator" >
     <density value="3.295" units="g/cc" />


### PR DESCRIPTION
This adds a function that returns the reflector geometry, along with the material definitions, see plot colored by cell.
![image](https://github.com/dean-krueger/NTR-Project/assets/84034227/536e4496-7508-409e-8bd6-6fe90f8310b9)

Coloring by material shows that it is mainly Be, with exceptions for the CuB poison and inconel bolts
![image](https://github.com/dean-krueger/NTR-Project/assets/84034227/a4eddf83-60e7-4dfb-8ad1-e394784385c0)

Drums can be rotated by via the clocking arg, the leftmost drum serves as the reference. Setting clocking to 60 yields the following geometry, for example
![image](https://github.com/dean-krueger/NTR-Project/assets/84034227/811a0dbd-5eef-4d58-b0c8-5be01c54caab)

I don't recall how we are doing height for these functions, but I can add an arg without any trouble.

closes #10 
closes #11 

perhaps closes #14 unless you need any additional materials?

leaving #12  for the completion of the inner rings and edge elements of the core
